### PR TITLE
Add screenshot command with png/scr format

### DIFF
--- a/CommandLine/Commands/ScreenshotCommand.cs
+++ b/CommandLine/Commands/ScreenshotCommand.cs
@@ -1,0 +1,53 @@
+﻿using PixelWorld;
+using PixelWorld.Display;
+using PixelWorld.Tools;
+using Spectre.Console.Cli;
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing.Imaging;
+using System.IO;
+
+namespace CommandLine.Commands
+{
+    [Description("Create screenshots from memory or snapshots")]
+    public class ScreenshotCommand : Command<ScreenshotSettings>
+    {
+        public override int Execute([NotNull] CommandContext context, [NotNull] ScreenshotSettings settings)
+        {
+            var fileNames = Utils.MatchGlobWithFiles(settings.Glob);
+
+            foreach (var fileName in fileNames)
+            {
+                Out.Write($"Opening file {fileName}");
+                using var file = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+                Dumper.ProcessStream(fileName, file, (a, b) => WriteScreenToDisk(a, b, settings), true);
+            }
+
+            return 0;
+        }
+
+        static int WriteScreenToDisk(string fileName, ArraySegment<byte> memory, ScreenshotSettings settings)
+        {
+            var address = settings.Address ?? (memory.Count == 49152 ? 0 : 16384);
+
+            if (settings.Png)
+            {
+                var newFileName = Path.Combine(settings.OutputFolder, Path.ChangeExtension(Path.GetFileName(fileName), "png"));
+                Out.Write($"  Dumping {fileName} @ {address} to {newFileName}");
+                using var bitmap = SpectrumDisplay.GetBitmap(memory.ToArray(), address);
+                bitmap.Save(newFileName, ImageFormat.Png);
+            }
+
+            if (settings.Scr || !settings.Png)
+            {
+                var newFileName = Path.Combine(settings.OutputFolder, Path.ChangeExtension(Path.GetFileName(fileName), "scr"));
+                Out.Write($"  Dumping {fileName} @ {address} to {newFileName}");
+                var screenBuffer = memory.Array.AsSpan(address, 6912).ToArray();
+                File.WriteAllBytes(newFileName, screenBuffer);
+            }
+
+            return 1;
+        }
+    }
+}

--- a/CommandLine/Commands/ScreenshotSettings.cs
+++ b/CommandLine/Commands/ScreenshotSettings.cs
@@ -1,0 +1,20 @@
+﻿using Spectre.Console.Cli;
+using System.ComponentModel;
+
+namespace CommandLine.Commands
+{
+    public class ScreenshotSettings : BasicSettings
+    {
+        [CommandOption("--address <MEMORY>")]
+        [Description("What memory address to use - otherwise auto detected.")]
+        public int? Address { get; set; }
+
+        [CommandOption("--png")]
+        [Description("Write a .png version of the screenshot.")]
+        public bool Png { get; set; }
+
+        [CommandOption("--scr")]
+        [Description("Write a .scr version of the screenshot.")]
+        public bool Scr { get; set; }
+    }
+}

--- a/CommandLine/Program.cs
+++ b/CommandLine/Program.cs
@@ -20,6 +20,7 @@ namespace CommandLine
                 config.AddCommand<DumpCommand>("dump");
                 config.AddCommand<HuntCommand>("hunt");
 
+                config.AddCommand<ScreenshotCommand>("screenshot");
                 config.AddCommand<PreviewCommand>("preview");
 
                 config.AddCommand<Z80AsmCommand>("z80asm");

--- a/CommandLine/Properties/launchSettings.json
+++ b/CommandLine/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "CommandLine": {
       "commandName": "Project",
-      "commandLineArgs": "dump sceptre.sna .",
-      "workingDirectory": "C:\\Users\\Damien\\Desktop"
+      "commandLineArgs": "hunt \"Zub (1986)(Mastertronic Added Dimension).dmp\" .",
+      "workingDirectory": "e:\\Retro\\_Mixed\\fonts\\Sinclair\\RAM"
     }
   }
 }

--- a/Common/BinarySource/IBinarySource.cs
+++ b/Common/BinarySource/IBinarySource.cs
@@ -5,6 +5,6 @@ namespace PixelWorld.BinarySource
 {
     public interface IBinarySource
     {
-        ArraySegment<byte> Read(Stream source);
+        ArraySegment<byte> GetMemory(Stream source);
     }
 }

--- a/Common/BinarySource/RawBinarySource.cs
+++ b/Common/BinarySource/RawBinarySource.cs
@@ -5,7 +5,7 @@ namespace PixelWorld.BinarySource
 {
     public class RawBinarySource : IBinarySource
     {
-        public ArraySegment<byte> Read(Stream input)
+        public ArraySegment<byte> GetMemory(Stream input)
         {
             return new ArraySegment<byte>(input.ReadAllBytes());
         }

--- a/Common/BinarySource/SNABinarySource.cs
+++ b/Common/BinarySource/SNABinarySource.cs
@@ -8,7 +8,7 @@ namespace PixelWorld.BinarySource
     {
         public static IBinarySource Instance { get; } = new SNABinarySource();
 
-        public ArraySegment<Byte> Read(Stream source)
+        public ArraySegment<Byte> GetMemory(Stream source)
         {
             var signatureBuffer = new byte[8];
             source.Read(signatureBuffer, 0, signatureBuffer.Length);
@@ -22,7 +22,7 @@ namespace PixelWorld.BinarySource
             }
 
             source.Seek(0, SeekOrigin.Begin);
-            return ZXSNABinarySource.Instance.Read(source);
+            return ZXSNABinarySource.Instance.GetMemory(source);
         }
     }
 }

--- a/Common/BinarySource/Z80BinarySource.cs
+++ b/Common/BinarySource/Z80BinarySource.cs
@@ -15,7 +15,7 @@ namespace PixelWorld.BinarySource
             ZXPlus3
         };
 
-        public ArraySegment<Byte> Read(Stream source)
+        public ArraySegment<Byte> GetMemory(Stream source)
         {
             // Use Ziggy's Z80 loader to decode the file
             try

--- a/Common/BinarySource/ZXSNABinarySource.cs
+++ b/Common/BinarySource/ZXSNABinarySource.cs
@@ -8,7 +8,7 @@ namespace PixelWorld.BinarySource
     {
         public static IBinarySource Instance { get; } = new ZXSNABinarySource();
 
-        public ArraySegment<Byte> Read(Stream source)
+        public ArraySegment<Byte> GetMemory(Stream source)
         {
             // Use Ziggy SNA loader to decode the file
             try

--- a/Common/DumpScanners/SpectrumDumpScanner.cs
+++ b/Common/DumpScanners/SpectrumDumpScanner.cs
@@ -76,13 +76,6 @@ namespace PixelWorld.DumpScanners
             return sha1.ToHex() == "7fa0e307a6e78cf198c3a480a18437dcbecae485c22634cea69cdea3240e7079fe6bedc3c35a76047fb244b4fa15aa35";
         }
 
-        public static Bitmap GetScreenPreview(BinaryReader reader)
-        {
-            reader.BaseStream.Seek(16384, SeekOrigin.Begin);
-            var buffer = reader.ReadBytes(screenLength);
-            return buffer.IsEmpty(0, buffer.Length) ? null : SpectrumDisplay.GetBitmap(buffer, 0);
-        }
-
         private static readonly KnownCharPattern[] RarelyChangedRomChars = {
             new KnownCharPattern(3, new byte[] // #
             {
@@ -151,7 +144,5 @@ namespace PixelWorld.DumpScanners
                 0b00111100
             })
         };
-
-        private const int screenLength = 6912;
     }
 }

--- a/Common/Formatters/ByteFontFormatter.cs
+++ b/Common/Formatters/ByteFontFormatter.cs
@@ -46,10 +46,11 @@ namespace PixelWorld.Formatters
         {
             fallback ??= blankWriter;
 
-           var writer = new BinaryWriter(output);
+            using var writer = new BinaryWriter(output);
             for (var i = 0; i < length; i++)
             {
-                if (charset.TryGetValue(i, out var charToWrite) && font.Glyphs.TryGetValue(charToWrite, out var glyph)) {
+                if (charset.TryGetValue(i, out var charToWrite) && font.Glyphs.TryGetValue(charToWrite, out var glyph))
+                {
                     for (int y = 0; y < charHeight; y++)
                     {
                         var b = new Byte();
@@ -60,7 +61,8 @@ namespace PixelWorld.Formatters
                         }
                         writer.Write(b);
                     }
-                } else
+                }
+                else
                 {
                     var buffer = fallback((int)writer.BaseStream.Position);
                     writer.Write(buffer.Array, buffer.Offset, buffer.Count);

--- a/Common/OffsetFinders/KnownCharPatternFinder.cs
+++ b/Common/OffsetFinders/KnownCharPatternFinder.cs
@@ -19,7 +19,7 @@ namespace PixelWorld.OffsetFinders
     {
         public static List<int> FindOffsets(byte[] buffer, KnownCharPattern[] knownFont)
         {
-            var offsets = new List<int>();
+            var offsets = new HashSet<int>();
 
             var end = buffer.Length - Spectrum.FontSize;
 
@@ -36,7 +36,7 @@ namespace PixelWorld.OffsetFinders
                 }
             }
 
-            return offsets;
+            return new List<int>(offsets);
         }
     }
 }

--- a/Common/Tools/PreviewCreator.cs
+++ b/Common/Tools/PreviewCreator.cs
@@ -15,7 +15,7 @@ namespace PixelWorld.Tools
                 using var source = File.OpenRead(fileName);
                 using var reader = new BinaryReader(source);
                 var sourceFont = ByteFontFormatter.Create(reader, Path.GetFileNameWithoutExtension(fileName), 0, Spectrum.UK);
-                var bitmap = sourceFont.CreateBitmap();
+                using var bitmap = sourceFont.CreateBitmap();
                 bitmap.Save(Utils.MakeFileName(fileName, "png", outputFolder));
             }
 


### PR DESCRIPTION
Allow screenshots to be produced from memory dumps or snapshots using the `screenshot` command.

- `--address` allows the memory address to be specified (otherwise it will be 16384 on 64K-sized snapshots as it assumes it includes the ROM and 0 on 48K screenshots)
- `--png` will write a screenshot in png format
- `--scr` will write a screenshot in raw/scr format (view with something like Recoil)

Not specifying either option will default to `--scr`. You can specify both if you want screenshots in both.