### PR TITLE
Add --flashed flag for screenshot generation

### DIFF
--- a/CommandLine/Commands/ScreenshotCommand.cs
+++ b/CommandLine/Commands/ScreenshotCommand.cs
@@ -36,7 +36,7 @@ namespace CommandLine.Commands
             {
                 var newFileName = Path.Combine(settings.OutputFolder, Path.ChangeExtension(Path.GetFileName(fileName), "png"));
                 Out.Write($"  Dumping {fileName} @ {address} to {newFileName}");
-                using var bitmap = SpectrumDisplay.GetBitmap(memory.ToArray(), address);
+                using var bitmap = SpectrumDisplay.GetBitmap(memory.ToArray(), address, settings.Flashed);
                 bitmap.Save(newFileName, ImageFormat.Png);
             }
 

--- a/CommandLine/Commands/Settings/ScreenshotSettings.cs
+++ b/CommandLine/Commands/Settings/ScreenshotSettings.cs
@@ -14,7 +14,11 @@ namespace CommandLine.Commands.Settings
         public bool Png { get; set; }
 
         [CommandOption("--scr")]
-        [Description("Write a .scr version of the screenshot.")]
+        [Description("Write a .scr version of the screenshot (default).")]
         public bool Scr { get; set; }
+
+        [CommandOption("--flashed")]
+        [Description("Write png with the alternate flashed attribute state.")]
+        public bool Flashed { get; set; }
     }
 }

--- a/CommandLine/Properties/launchSettings.json
+++ b/CommandLine/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "CommandLine": {
       "commandName": "Project",
-      "commandLineArgs": "chead *.ch8 test",
-      "workingDirectory": "d:\\zxo\\_Ports\\Micropack"
+      "commandLineArgs": "screenshot *.z80 --png --flashed",
+      "workingDirectory": "c:\\temp"
     }
   }
 }


### PR DESCRIPTION
Adds a new `--flashed` flag that produces the alternative "flashed" version of a screenshot when written to png files.

e.g. On the Manic Miner title screen performing

`screenshot Manic*.z80 --png` will produce:
![Manic Miner (1983)(Software Projects)](https://user-images.githubusercontent.com/118951/198846121-876ed7c5-e1c8-4e75-817f-90267f3b9c5b.png)

`screenshot Manic*.z80 --png --flashed` will produce:
![Manic Miner (1983)(Software Projects)](https://user-images.githubusercontent.com/118951/198846106-a71aeb14-c9c5-4a50-bda4-92bbf93d2dd3.png)
