### PR TITLE
Support writing screenshots to animated GIFs

### DIFF
--- a/CommandLine/Commands/ScreenshotCommand.cs
+++ b/CommandLine/Commands/ScreenshotCommand.cs
@@ -40,7 +40,19 @@ namespace CommandLine.Commands
                 bitmap.Save(newFileName, ImageFormat.Png);
             }
 
-            if (settings.Scr || !settings.Png)
+            if (settings.Gif)
+            {
+                var newFileName = Path.Combine(settings.OutputFolder, Path.ChangeExtension(Path.GetFileName(fileName), "gif"));
+                Out.Write($"  Dumping {fileName} @ {address} to {newFileName}");
+                using var animatedGif = AnimatedGif.AnimatedGif.Create(newFileName, 320); // 25 fps
+                using var frameOne = SpectrumDisplay.GetBitmap(memory.ToArray(), address, false);
+                animatedGif.AddFrame(frameOne, quality: AnimatedGif.GifQuality.Bit8);
+                using var frameTwo = SpectrumDisplay.GetBitmap(memory.ToArray(), address, true);
+                animatedGif.AddFrame(frameTwo, quality: AnimatedGif.GifQuality.Bit8);
+            }
+
+            // Write SCR if specified OR if nothing specified (so it is the default)
+            if (settings.Scr |(!settings.Png && !settings.Gif))
             {
                 var newFileName = Path.Combine(settings.OutputFolder, Path.ChangeExtension(Path.GetFileName(fileName), "scr"));
                 Out.Write($"  Dumping {fileName} @ {address} to {newFileName}");

--- a/CommandLine/Commands/Settings/ScreenshotSettings.cs
+++ b/CommandLine/Commands/Settings/ScreenshotSettings.cs
@@ -17,6 +17,10 @@ namespace CommandLine.Commands.Settings
         [Description("Write a .scr version of the screenshot (default).")]
         public bool Scr { get; set; }
 
+        [CommandOption("--gif")]
+        [Description("Write an animated .gif of the screenshot.")]
+        public bool Gif { get; set; }
+
         [CommandOption("--flashed")]
         [Description("Write png with the alternate flashed attribute state.")]
         public bool Flashed { get; set; }

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AnimatedGif" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />


### PR DESCRIPTION
Adds a `--gif` option to the `screenshot` command which creates animated two-frame GIFs containing both frames of the screen.

![Manic Miner (1983)(Software Projects)](https://user-images.githubusercontent.com/118951/198846983-25dbdcb9-4cd2-4200-aa2f-97a933f72cca.gif)

Note: For many screenshots this will just be two duplicate frames of the same content unless the FLASH attribute is in use.