### PR TITLE
Add new extracttiles command

### DIFF
--- a/CommandLine/Commands/ExtractScreenTilesCommand.cs
+++ b/CommandLine/Commands/ExtractScreenTilesCommand.cs
@@ -1,0 +1,19 @@
+﻿using PixelWorld;
+using PixelWorld.Tools;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using CommandLine.Commands.Settings;
+
+namespace CommandLine.Commands;
+
+[Description("Dump memory from emulator snapshot")]
+public class ExtractScreenTilesCommand : Command<ExtractTilesSettings>
+{
+    public override int Execute([NotNull] CommandContext context, [NotNull] ExtractTilesSettings settings)
+    {
+        var files = Utils.MatchGlobWithFiles(settings.Glob);
+        TileExtractor.Extract(files, settings.OutputFolder, settings.MinTiles, settings.MaxTiles);
+        return 0;
+    }
+}

--- a/CommandLine/Commands/Settings/ExtractTilesSettings.cs
+++ b/CommandLine/Commands/Settings/ExtractTilesSettings.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace CommandLine.Commands.Settings;
+
+public class ExtractTilesSettings : RequiredSettings
+{
+    [CommandOption("--min <NUMBER>")]
+    [Description("Minimum number of unique tiles for extraction")]
+    [DefaultValue("1")]
+    public int MinTiles { get; set; } = 1;
+    
+    [CommandOption("--max <NUMBER>")]
+    [Description("Maximum number of unique tiles for extraction")]
+    [DefaultValue("768")]
+    public int MaxTiles { get; set; } = 768;
+}

--- a/Common/Tools/TileExtractor.cs
+++ b/Common/Tools/TileExtractor.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using PixelWorld.Display;
+
+namespace PixelWorld.Tools;
+
+public class TileExtractor
+{
+    public static void Extract(List<string> fileNames, string outputFolder, int minTiles, int maxTiles)
+    {
+        var inputsWithOutputsCount = 0;
+        var outputCount = 0;
+
+        var inputCount = fileNames.Count;
+        Out.Write($"Extracting screen tiles from {inputCount} files");
+
+        foreach (var fileName in fileNames)
+        {
+            Out.Write($"Opening file {fileName}");
+
+            using var source = File.OpenRead(fileName);
+            using var reader = new BinaryReader(source);
+            var buffer = reader.ReadBytes(1024 * 2048);
+            var address = buffer.Length == 65536 ? 16384 : 0;
+            var tiles = SpectrumDisplay.GetCandidates(buffer, address);
+
+            if (tiles.Length > maxTiles)
+                Out.Write($"  Skipping {tiles.Length} tiles as greater than {maxTiles} maxTiles setting");
+            else if (tiles.Length < minTiles)
+                Out.Write($"  Skipping {tiles.Length} tiles as less than {minTiles} minTiles setting");
+            else
+            {
+                var newFileName = Utils.MakeFileName(Path.GetFileNameWithoutExtension(fileName), "tiles", outputFolder);
+                Out.Write($"  Creating {tiles.Length} tiles in {newFileName}");
+                using var target = File.Create(newFileName);
+                foreach (var tile in tiles)
+                foreach (var row in tile)
+                    target.WriteByte(row);
+                inputsWithOutputsCount++;
+                outputCount += tiles.Length;
+            }
+        }
+
+        Out.Write($"{inputsWithOutputsCount} files yielded {outputCount} tiles");
+        Out.Write($"{Math.Floor((double)inputsWithOutputsCount / inputCount * 100)}% success rate");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ It also contains bulk-ripping `dump` and `hunt` commands for obtaining ZX Spectr
 
 - `dump` to RAM-dump snapshot files (currently supports `.z80` and `.sna` and recurses through `.zip` archives)
 - `hunt` to look through RAM dumps for possible bitmap fonts (currently supports only ZX Spectrum fonts)
-- `screenshot` to create a screenshot from a RAM-dump or snapshot files (in PNG, SCR or animated GIF format)
+- `screenshot` to create a screenshots from RAM-dumps or snapshot files (in PNG, SCR or animated GIF format)
+- `extracttiles` to create a files with unique 8x8 character tiles found on the screen in RAM-dumps or snapshot files
 
 ### Conversions
 


### PR DESCRIPTION
New `extracttiles` command allows all unique tiles to be ripped from a ZX Spectrum screenshot

Implements #20 